### PR TITLE
Revert "feat: added gitlab_pages_external_url var and updated async tasks for dry run"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,5 +81,3 @@ gitlab_letsencrypt_auto_renew_hour: 1
 gitlab_letsencrypt_auto_renew_minute: 30
 gitlab_letsencrypt_auto_renew_day_of_month: "*/7"
 gitlab_letsencrypt_auto_renew: true
-
-gitlab_pages_external_url: "https://{{ gitlab_domain }}/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
   package:
     name: "{{ gitlab_package_name }}"
     state: present
-  async: "{{ ansible_check_mode | ternary(0, 3000) }}"
+  async: 3000
   poll: 5
   when: (gitlab_version is defined) and (gitlab_version|length > 0)
 
@@ -51,7 +51,7 @@
   package:
     name: "{{ gitlab_edition }}"
     state: latest
-  async: "{{ ansible_check_mode | ternary(0, 3000) }}"
+  async: 3000
   poll: 5
   when: (gitlab_version is not defined) or (gitlab_version|length == 0)
 

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -97,8 +97,6 @@ registry_nginx['ssl_certificate'] = "{{ gitlab_registry_nginx_ssl_certificate }}
 registry_nginx['ssl_certificate_key'] = "{{ gitlab_registry_nginx_ssl_certificate_key }}"
 {% endif %}
 
-pages_external_url "{{ gitlab_pages_external_url }}"
-
 {% if gitlab_extra_settings is defined %}
 # Extra configuration
 {% for extra in gitlab_extra_settings %}


### PR DESCRIPTION
Reverts cristianocasella/ansible-role-gitlab#1

Reverting as this change bringed the following error in the test environment:

```
TASK [gitlab-ansible : Install GitLab specific version] ************************
task path: /home/gitlab-runner/.ansible/roles/gitlab-ansible/tasks/main.yml:42
The full traceback is:
NoneType: None
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "check mode and async cannot be used on same task."
}
```