### PR TITLE
feat: ai gateway variables enabled

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,3 +83,18 @@ gitlab_letsencrypt_auto_renew_day_of_month: "*/7"
 gitlab_letsencrypt_auto_renew: true
 
 gitlab_pages_external_url: "https://{{ gitlab_domain }}/"
+
+# Extra setting configuration.
+
+gitlab_extra_settings:
+  - gitlab_rails:
+      - key: "dependency_proxy_enabled"
+        value: "false"
+      - key: "env"
+        value:
+          GITLAB_LICENSE_MODE: "production"
+          CUSTOMER_PORTAL_URL: "https://customers.gitlab.com"
+          AI_GATEWAY_URL: "<path_to_your_ai_gateway>:<port>"
+  - gitlab_pages:
+      - key: "enable"
+        value: "true"

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -104,14 +104,19 @@ pages_external_url "{{ gitlab_pages_external_url }}"
 {% for extra in gitlab_extra_settings %}
 {% for setting in extra %}
 {% for kv in extra[setting] %}
-{% if (kv.type is defined and kv.type == 'plain') or (kv.value is not string) %}
+{% if kv.key == 'env' and kv.value is mapping %}
+{{ setting }}['{{ kv.key }}'] = {
+{% for env_key, env_value in kv.value.items() %}
+  '{{ env_key }}' => '{{ env_value }}',
+{% endfor %}
+}
+{% elif (kv.type is defined and kv.type == 'plain') or (kv.value is not string) %}
 {{ setting }}['{{ kv.key }}'] = {{ kv.value }}
 {% else %}
 {{ setting }}['{{ kv.key }}'] = '{{ kv.value }}'
 {% endif %}
 {% endfor %}
 {% endfor %}
-
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
As described in the issue #5 I implement the new parameters to use the AI Gateway for the self-hosted models. 

I use this playbook to test the result of the configuration: 

```
---
- name: Test GitLab template rendering
  hosts: localhost
  gather_facts: no
  vars:
    gitlab_domain: gitlab
    gitlab_external_url: "https://{{ gitlab_domain }}/"
    gitlab_git_data_dir: "/var/opt/gitlab/git-data"
    gitlab_edition: "gitlab-ce"
    gitlab_version: ''
    gitlab_backup_path: "/var/opt/gitlab/backups"
    gitlab_config_template: "gitlab.rb.j2"

    # SSL Configuration.
    gitlab_redirect_http_to_https: true
    gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_domain }}.crt"
    gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_domain }}.key"

    # SSL Self-signed Certificate Configuration.
    gitlab_create_self_signed_cert: true
    gitlab_self_signed_cert_subj: "/C=US/ST=Missouri/L=Saint Louis/O=IT/CN={{ gitlab_domain }}"

    # LDAP Configuration.
    gitlab_ldap_enabled: true
    gitlab_ldap_host: "example.com"
    gitlab_ldap_port: "389"
    gitlab_ldap_uid: "sAMAccountName"
    gitlab_ldap_method: "plain"
    gitlab_ldap_bind_dn: "CN=Username,CN=Users,DC=example,DC=com"
    gitlab_ldap_password: "password"
    gitlab_ldap_base: "DC=example,DC=com"

    # SMTP Configuration
    gitlab_smtp_enable: true
    gitlab_smtp_address: "smtp.server"
    gitlab_smtp_port: "465"
    gitlab_smtp_user_name: "smtp user"
    gitlab_smtp_password: "smtp password"
    gitlab_smtp_domain: "example.com"
    gitlab_smtp_authentication: "login"
    gitlab_smtp_enable_starttls_auto: true
    gitlab_smtp_tls: false
    gitlab_smtp_openssl_verify_mode: "none"
    gitlab_smtp_ca_path: "/etc/ssl/certs"
    gitlab_smtp_ca_file: "/etc/ssl/certs/ca-certificates.crt"

    # 2-way SSL Client Authentication support.
    gitlab_nginx_ssl_verify_client: ""
    gitlab_nginx_ssl_client_certificate: ""

    # Probably best to leave this as the default, unless doing testing.
    gitlab_restart_handler_failed_when: 'gitlab_restart.rc != 0'

    # Dependencies.
    gitlab_dependencies:
      - openssh-server
      - postfix
      - curl
      - openssl
      - tzdata
    gitlab_time_zone: "UTC"
    gitlab_email_from: "gitlab@example.com"
    gitlab_email_display_name: "Gitlab"
    gitlab_email_reply_to: "gitlab@example.com"

    # Registry configuration.
    gitlab_registry_enable: true
    gitlab_registry_nginx_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
    gitlab_registry_nginx_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"

    # LetsEncrypt configuration.
    gitlab_letsencrypt_enable: true
    gitlab_letsencrypt_contact_emails: ["gitlab@example.com"]
    gitlab_letsencrypt_auto_renew_hour: 1
    gitlab_letsencrypt_auto_renew_minute: 30
    gitlab_letsencrypt_auto_renew_day_of_month: "*/7"
    gitlab_letsencrypt_auto_renew: true

    gitlab_pages_external_url: "https://{{ gitlab_domain }}/"
    gitlab_backup_keep_time: "604800"
    gitlab_default_theme: 3
    gitlab_registry_external_url: "https://registry-test.it"
    gitlab_email_enabled: true
    gitlab_extra_settings:
      - gitlab_rails:
          - key: "dependency_proxy_enabled"
            value: "false"
          - key: "env"
            value:
              GITLAB_LICENSE_MODE: "production"
              CUSTOMER_PORTAL_URL: "https://customers.gitlab.com"
              AI_GATEWAY_URL: "<path_to_your_ai_gateway>:<port>"
      - gitlab_pages:
          - key: "enable"
            value: "true"
  tasks:
    - name: Render GitLab configuration template
      template:
        src: templates/gitlab.rb.j2
        dest: /tmp/gitlab.rb
      delegate_to: localhost

    - name: Display rendered template
      command: cat /tmp/gitlab.rb
      register: rendered_template
      delegate_to: localhost

    - debug:
        msg: "{{ rendered_template.stdout }}"

```