### PR TITLE
fix: Removed deprecated declaration for LDAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ GitLab LetsEncrypt configuration; tells GitLab whether to request and use a cert
     gitlab_ldap_base: "DC=example,DC=com"
 
 GitLab LDAP configuration; if `gitlab_ldap_enabled` is `true`, the rest of the configuration will tell GitLab how to connect to an LDAP server for centralized authentication.
+This approach support a single ldap server configuration, in case you need to configure multiple server is suggested that extrasettings array approach is used.
 
     gitlab_dependencies:
       - openssh-server

--- a/templates/gitlab.rb.j2
+++ b/templates/gitlab.rb.j2
@@ -45,18 +45,24 @@ gitaly['configuration'] = {
 # The directory where Gitlab backups will be stored
 gitlab_rails['backup_path'] = "{{ gitlab_backup_path }}"
 
-# These settings are documented in more detail at
-# https://gitlab.com/gitlab-org/gitlab-ce/blob/master/config/gitlab.yml.example#L118
-gitlab_rails['ldap_enabled'] = {{ gitlab_ldap_enabled | lower }}
+# For LDAP settings, with the multi-server support, for a single server, the template has been migrated and the same variables can be used.
+# For multiple server is suggested that extrasettings array approach is used
+# https://docs.gitlab.com/administration/auth/ldap/?tab=Linux+package+(Omnibus)#configure-ldap
 {% if gitlab_ldap_enabled %}
-gitlab_rails['ldap_host'] = '{{ gitlab_ldap_host }}'
-gitlab_rails['ldap_port'] = {{ gitlab_ldap_port }}
-gitlab_rails['ldap_uid'] = '{{ gitlab_ldap_uid }}'
-gitlab_rails['ldap_method'] = '{{ gitlab_ldap_method}}' # 'ssl' or 'plain'
-gitlab_rails['ldap_bind_dn'] = '{{ gitlab_ldap_bind_dn }}'
-gitlab_rails['ldap_password'] = '{{ gitlab_ldap_password }}'
-gitlab_rails['ldap_allow_username_or_email_login'] = true
-gitlab_rails['ldap_base'] = '{{ gitlab_ldap_base }}'
+gitlab_rails['ldap_enabled'] = {{ gitlab_ldap_enabled | lower }}
+gitlab_rails['ldap_servers'] = {
+  'main' => {
+    'label' => 'LDAP',
+    'host' =>  '{{ gitlab_ldap_host }}',
+    'port' => {{ gitlab_ldap_port }},
+    'uid' => '{{ gitlab_ldap_uid }}',
+    'encryption' => '{{ gitlab_ldap_method}}',
+    'bind_dn' => '{{ gitlab_ldap_bind_dn }}',
+    'password' => '{{ gitlab_ldap_password }}',
+    'allow_username_or_email_login' => true,
+    'base' => '{{ gitlab_ldap_base }}'
+  }
+}
 {% endif %}
 
 # GitLab Nginx


### PR DESCRIPTION
GitLab now support multiple ldap servers, removing the single server declaration.